### PR TITLE
Update 'request' and outdated npm packages to fix 'cryptiles' security vulnerability

### DIFF
--- a/auth-server/package-lock.json
+++ b/auth-server/package-lock.json
@@ -14,14 +14,14 @@
             }
         },
         "ajv": {
-            "version": "5.5.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "version": "6.12.3",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+            "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
             "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
+                "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             }
         },
         "array-flatten": {
@@ -82,14 +82,6 @@
                 "type-is": "~1.6.16"
             }
         },
-        "boom": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-            "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-            "requires": {
-                "hoek": "4.x.x"
-            }
-        },
         "bytes": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -99,11 +91,6 @@
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-        },
-        "co": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
         "combined-stream": {
             "version": "1.0.8",
@@ -124,23 +111,23 @@
             "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
         },
         "cookie": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
-            "integrity": "sha1-cv7D0k5Io0Mgc9kMEmQgBQYQBLE="
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+            "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
         },
         "cookie-parser": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.2.tgz",
-            "integrity": "sha1-UiEcyCyVXXn/DAiJVEB3JOGc9WI=",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
+            "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
             "requires": {
-                "cookie": "0.1.2",
-                "cookie-signature": "1.0.4"
+                "cookie": "0.4.0",
+                "cookie-signature": "1.0.6"
             }
         },
         "cookie-signature": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz",
-            "integrity": "sha1-Dt0iKG46ERuaKnDbNj6SXoZ/aso="
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -154,24 +141,6 @@
             "requires": {
                 "object-assign": "^4",
                 "vary": "^1"
-            }
-        },
-        "cryptiles": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.4.tgz",
-            "integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
-            "requires": {
-                "boom": "5.x.x"
-            },
-            "dependencies": {
-                "boom": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-                    "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-                    "requires": {
-                        "hoek": "4.x.x"
-                    }
-                }
             }
         },
         "dashdash": {
@@ -299,9 +268,9 @@
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
@@ -361,29 +330,13 @@
             "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "requires": {
-                "ajv": "^5.1.0",
+                "ajv": "^6.5.5",
                 "har-schema": "^2.0.0"
             }
-        },
-        "hawk": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-            "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-            "requires": {
-                "boom": "4.x.x",
-                "cryptiles": "3.x.x",
-                "hoek": "4.x.x",
-                "sntp": "2.x.x"
-            }
-        },
-        "hoek": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-            "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
         },
         "http-errors": {
             "version": "1.6.3",
@@ -445,9 +398,9 @@
             "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-traverse": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "json-stringify-safe": {
             "version": "5.0.1",
@@ -509,9 +462,9 @@
             "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
         },
         "oauth-sign": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
         "object-assign": {
             "version": "4.1.1",
@@ -550,10 +503,15 @@
                 "ipaddr.js": "1.9.1"
             }
         },
+        "psl": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+        },
         "punycode": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "qs": {
             "version": "6.5.2",
@@ -582,32 +540,30 @@
             }
         },
         "request": {
-            "version": "2.83.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
             "requires": {
                 "aws-sign2": "~0.7.0",
-                "aws4": "^1.6.0",
+                "aws4": "^1.8.0",
                 "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.1",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
                 "forever-agent": "~0.6.1",
-                "form-data": "~2.3.1",
-                "har-validator": "~5.0.3",
-                "hawk": "~6.0.2",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
                 "http-signature": "~1.2.0",
                 "is-typedarray": "~1.0.0",
                 "isstream": "~0.1.2",
                 "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.17",
-                "oauth-sign": "~0.8.2",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
                 "performance-now": "^2.1.0",
-                "qs": "~6.5.1",
-                "safe-buffer": "^5.1.1",
-                "stringstream": "~0.0.5",
-                "tough-cookie": "~2.3.3",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
                 "tunnel-agent": "^0.6.0",
-                "uuid": "^3.1.0"
+                "uuid": "^3.3.2"
             }
         },
         "safe-buffer": {
@@ -656,14 +612,6 @@
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
             "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         },
-        "sntp": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-            "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-            "requires": {
-                "hoek": "4.x.x"
-            }
-        },
         "sshpk": {
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -685,17 +633,13 @@
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
             "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         },
-        "stringstream": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-            "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
-        },
         "tough-cookie": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-            "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
             "requires": {
-                "punycode": "^1.4.1"
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
             }
         },
         "tunnel-agent": {
@@ -724,6 +668,14 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "requires": {
+                "punycode": "^2.1.0"
+            }
         },
         "utils-merge": {
             "version": "1.0.1",

--- a/auth-server/package.json
+++ b/auth-server/package.json
@@ -4,11 +4,11 @@
     "description": "Basic examples of the Spotify authorization flows through OAuth 2",
     "version": "0.0.2",
     "dependencies": {
-        "cookie-parser": "1.3.2",
+        "cookie-parser": "^1.4.5",
         "cors": "^2.8.4",
         "dotenv": "^8.2.0",
         "express": "~4.16.0",
         "querystring": "~0.2.0",
-        "request": "~2.83.0"
+        "request": "2.88.2"
     }
 }


### PR DESCRIPTION
I got a message about there being a security vulnerability with the 'cryptiles' npm package. 

It was a dependency for the 'request' package. I ran `npm audit fix` to update any packages that were out of date. I also changed the 'request' version in package.json to the latest 2.88.2 which seemed to remove 'cryptiles' altogether