### PR TITLE
Player reload & PlayQueue display updates

### DIFF
--- a/client/src/components/Player/index.js
+++ b/client/src/components/Player/index.js
@@ -10,10 +10,11 @@ const Player = props => {
 				'Content-Type': 'application/json'
 			}
 		})
-			.then(res => res.json())
+			.then(() => props.getCurrentlyPlaying(props.token))
 			.catch(err => console.log(err));
 	};
 
+	// POST that changes to next song in users playback. After track is changed, we GET current playback data to update displaying track data
 	const handleNextClick = token => {
 		fetch('https://api.spotify.com/v1/me/player/next', {
 			method: 'POST',
@@ -21,7 +22,9 @@ const Player = props => {
 				Authorization: 'Bearer ' + token,
 				'Content-Type': 'application/json'
 			}
-		}).catch(err => console.log(err));
+		})
+			.then(() => props.getCurrentlyPlaying(props.token))
+			.catch(err => console.log(err));
 	};
 
 	return (

--- a/client/src/components/Queue/index.js
+++ b/client/src/components/Queue/index.js
@@ -10,7 +10,7 @@ const Queue = props => {
 					height: '200px',
 					overflowY: 'auto'
 				}}>
-				<ListGroup variant="dark">{props.handleQueueRender()}</ListGroup>
+				<ListGroup>{props.handleQueueRender()}</ListGroup>
 			</div>
 		</div>
 	);

--- a/client/src/components/TrackSearch/index.js
+++ b/client/src/components/TrackSearch/index.js
@@ -64,9 +64,10 @@ class TrackSearch extends Component {
 		this.props.addTrackToDisplayQueue(this.props.roomId, e.target.id, e.target.innerText);
 
 		this.addTrackToPlaybackQueue(this.props.token, e.target.id);
+		this.props.getCurrentlyPlaying(this.props.token);
 
 		// Reset state of track input and hide the trackListDisplay
-		this.setState({ trackInput: '', trackListDisplay: 'd-none' });
+		this.setState({ trackInput: '', trackListDisplay: 'd-none', searchBtnIcon: 'fa fa-search' });
 	};
 
 	render() {


### PR DESCRIPTION
Passed down getCurrentlyPlaying method down as a prop to TrackSearch and Player. The data on Room page will update when a track is skipped, played or paused, if necessary. Also wrote setVariant method to conditionally set a variant based on parameters. This will be used to highlight the track that is currently playing inside of the Play Queue component.