### PR TITLE
Emit room host's current song

### DIFF
--- a/server.js
+++ b/server.js
@@ -57,6 +57,12 @@ io.on('connect', socket => {
 		io.in(roomId).emit('current users', currentUsers);
 	});
 
+	// Listen for the host's current song, then emit that to the room for new users who join
+	socket.on('host song', ({ song, room }) => {
+		io.in(room).emit('current song', song);
+	});
+
+	// When a socket disconnects, remove user from usersArray
 	socket.on('disconnect', () => {
 		let user = handlers.removeUser(socket);
 


### PR DESCRIPTION
It may be possible that the host is already playing a song when a new user joins the room.

Thus, we are creating a host of the room. They are always the first person in the usersArray.
If a new user joins, they will get the host's current song so that it gets added to the new user's playback queue and they can "catch up" to where the host is.

Next, I'll work on adding the host's currently playing song to the new user's playback queue, so they can start playing along with the host.

We will also add in your piece where the new user will also get the room's queues of future songs. From the current song on, the users should be in sync as long as they use the Playlistr app to control the songs.