### PR TITLE
Make host's song the roomSong for the room

### DIFF
--- a/server.js
+++ b/server.js
@@ -57,9 +57,10 @@ io.on('connect', socket => {
 		io.in(roomId).emit('current users', currentUsers);
 	});
 
-	// Listen for the host's current song, then emit that to the room for new users who join
-	socket.on('host song', ({ song, room }) => {
-		io.in(room).emit('current song', song);
+	// Emit the host's song as the entire room's song
+	// Does not emit to sender who is the host
+	socket.on('host song', ({ song, roomId }) => {
+		socket.to(roomId).emit('room song', song);
 	});
 
 	// When a socket disconnects, remove user from usersArray


### PR DESCRIPTION
Whenever getCurrentlyPlaying is called, we will have the host set the roomSong for the entire room. This will then be emitted to the server through the 'host song' socket.

When a new user joins, they will also mount and call getCurrentlyPlaying but will not set the roomSong since they're not the host. They will listen for the 'room song' socket and then set that song to their roomSong as well.

Next I will work on stopping the new user's current playback, adding the roomSong to their queue, and playing it from where the host/roomSong is.