### PR TITLE
Join Room Queue Sync

### DIFF
--- a/client/src/components/RoomButtons/index.js
+++ b/client/src/components/RoomButtons/index.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import hexGen from 'hex-generator';
 import { Link } from 'react-router-dom';
-import axios from 'axios';
 
 import API from '../../utils/API';
 import SpotifyAPI from '../../utils/SpotifyAPI';
@@ -71,9 +70,7 @@ class RoomButtons extends Component {
 	handleCreateRoom = e => {
 		e.preventDefault();
 
-		axios.post('/api/rooms', {
-			room_id: this.state.roomHex
-		})
+		API.createRoom(this.state.roomHex)
 			.then(() => this.setUrl(this.props.token, this.state.roomHex))
 			.catch(err => console.log(err));
 	};

--- a/client/src/components/RoomButtons/index.js
+++ b/client/src/components/RoomButtons/index.js
@@ -44,10 +44,6 @@ class RoomButtons extends Component {
 		}
 	};
 
-	// startNextTrack = token => {
-	// 	SpotifyAPI.playNextTrack(token).catch(err => console.log(err));
-	// };
-
 	syncQueueWithRoomAndJoin = roomId => {
 		API.getTracks(roomId)
 			.then(res => {

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+export default {
+	getTracks: roomId => {
+		return axios.get(`/api/rooms/${roomId}`);
+	}
+};

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -1,6 +1,11 @@
 import axios from 'axios';
 
 export default {
+	createRoom: roomId => {
+		return axios.post('/api/rooms', {
+			room_id: roomId
+		});
+	},
 	getTracks: roomId => {
 		return axios.get(`/api/rooms/${roomId}`);
 	}

--- a/client/src/utils/SpotifyAPI.js
+++ b/client/src/utils/SpotifyAPI.js
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+export default {
+	addTrackToQueue: (token, trackId) => {
+		return axios({
+			method: 'POST',
+			url: `https://api.spotify.com/v1/me/player/queue?uri=spotify:track:${trackId}`,
+			headers: {
+				Authorization: `Bearer ${token}`
+			}
+		});
+	}
+};


### PR DESCRIPTION
Added functionality to Join Room button. When the user enters a Room ID and clicks Join Room we will: get all tracks associated with that room, filter out the tracks that have been played and add the remaining tracks (in order) to their playback queue on Spotify. Then the url will be set to enter the Room.

I also have begun switching all client side API calls to use axios