### PR TITLE
Emit play/pause/next actions to other users in room

### DIFF
--- a/client/src/components/Player/index.js
+++ b/client/src/components/Player/index.js
@@ -5,31 +5,6 @@ import ProgressBar from 'react-bootstrap/ProgressBar';
 import './style.css';
 
 const Player = props => {
-	const handlePlayPauseClick = (action, token) => {
-		fetch(`https://api.spotify.com/v1/me/player/${action}`, {
-			method: 'PUT',
-			headers: {
-				Authorization: 'Bearer ' + token,
-				'Content-Type': 'application/json'
-			}
-		})
-			.then(() => props.getCurrentlyPlaying(props.token))
-			.catch(err => console.log(err));
-	};
-
-	// POST that changes to next song in users playback. After track is changed, we GET current playback data to update displaying track data
-	const handleNextClick = token => {
-		fetch('https://api.spotify.com/v1/me/player/next', {
-			method: 'POST',
-			headers: {
-				Authorization: 'Bearer ' + token,
-				'Content-Type': 'application/json'
-			}
-		})
-			.then(() => props.getCurrentlyPlaying(props.token))
-			.catch(err => console.log(err));
-	};
-
 	const calcSongProgress = () => (props.progress / props.item.duration_ms) * 100;
 
 	return (
@@ -50,16 +25,25 @@ const Player = props => {
 					type="button"
 					id="button_play"
 					className="btn"
-					onClick={() => handlePlayPauseClick('play', props.token)}>
+					onClick={() => {
+						props.handlePlayPauseClick('play', props.token);
+						props.emitPlayerAction('play');
+					}}>
 					<i className="fa fa-play fa-lg"></i>
 				</button>
 				<button
 					type="button"
 					className="btn"
-					onClick={() => handlePlayPauseClick('pause', props.token)}>
+					onClick={() => {
+						props.handlePlayPauseClick('pause', props.token);
+						props.emitPlayerAction('pause');
+					}}>
 					<i className="fa fa-pause fa-lg"></i>
 				</button>
-				<button type="button" className="btn" onClick={() => handleNextClick(props.token)}>
+				<button type="button" className="btn" onClick={() => {
+					props.handleNextClick(props.token);
+					props.emitPlayerAction('next');
+				}}>
 					<i className="fa fa-forward fa-lg"></i>
 				</button>
 			</div>

--- a/client/src/pages/Room/style.css
+++ b/client/src/pages/Room/style.css
@@ -15,5 +15,5 @@
 }
 
 .play-queue h1 {
-	font-size: 3vw;
+	font-size: 2.25rem;
 }

--- a/client/src/utils/Socket.js
+++ b/client/src/utils/Socket.js
@@ -1,0 +1,6 @@
+import apiUrl from '../apiConfig';
+import socketIOClient from 'socket.io-client';
+
+const ENDPOINT = apiUrl;
+
+export const socket = socketIOClient(ENDPOINT);

--- a/client/src/utils/SpotifyAPI.js
+++ b/client/src/utils/SpotifyAPI.js
@@ -27,5 +27,25 @@ export default {
 				Authorization: `Bearer ${token}`
 			}
 		});
+	},
+	playPausePlayback: (action, token) => {
+		return axios({
+			method: 'PUT',
+			url: `https://api.spotify.com/v1/me/player/${action}`,
+			headers: {
+				Authorization: 'Bearer ' + token,
+				'Content-Type': 'application/json'
+			}
+		});
+	},
+	nextPlaybackTrack: token => {
+		return axios({
+			method: 'POST',
+			url: 'https://api.spotify.com/v1/me/player/next',
+			headers: {
+				Authorization: 'Bearer ' + token,
+				'Content-Type': 'application/json'
+			}
+		});
 	}
 };

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const express = require('express'),
 	mongoose = require('mongoose'),
 	routes = require('./routes'),
 	handlers = require('./handlers');
+const { KeyObject } = require('crypto');
 
 require('dotenv').config();
 
@@ -61,6 +62,11 @@ io.on('connect', socket => {
 	// Does not emit to sender who is the host
 	socket.on('host song', ({ song, roomId }) => {
 		socket.to(roomId).emit('room song', song);
+	});
+
+	// Emit play/pause/next actions to other users in room, exclude sender
+	socket.on('user action', ({ action, roomId }) => {
+		socket.to(roomId).emit('player action', action);
 	});
 
 	// When a socket disconnects, remove user from usersArray


### PR DESCRIPTION
Moved Socket connection to separate file to create only one socket connection. When a user clicks play, pause, or next, they control their own playback with that action via handlePlayPause/NextClick, but they also emit that action to all *other* users in the room via emitPlayerAction. The other users then receive that action from the server socket and that action is passed into their own player. I also removed some console.logs to reduce noise and refactored the handle functions into our SpotifyAPI util.

I had to move handlePlayPause/Next and emitPlayerAction functions into the parent Room component. The socket listener for 'player action' has to listen when the parent Room component mounts, and the handle functions in the child component would have to be called from the parent component.