### PR TITLE
Queue Render Bug Fix, Error Handling & Next Button Update

### DIFF
--- a/client/src/components/TrackSearch/index.js
+++ b/client/src/components/TrackSearch/index.js
@@ -55,11 +55,11 @@ class TrackSearch extends Component {
 	};
 
 	handleTrackSelection = e => {
-		API.addTrack(this.props.roomId, e.target.id, e.target.innerText).catch(err => console.log(err));
+		API.addTrack(this.props.roomId, e.target.id, e.target.innerText)
+			.then(() => this.props.setRoomTracks(this.props.roomId))
+			.catch(err => console.log(err));
 
 		this.emitNewTrackToRoom(this.props.roomId, e.target.id);
-
-		this.props.getRoomTracks(this.props.roomId);
 
 		this.props.addTrackToPlaybackQueue(this.props.token, e.target.id);
 


### PR DESCRIPTION
Renamed getRoomTracks() to setRoomTracks() to help identify the method as a state setting method. Repositioned setRoomTracks() inside of handleTrackSelection to be made after API.addTrack has completed. Did this to ensure the track is added before resetting state. 

Edited error handler of GET call inside of getCurrentlyPlaying. If the status is 204, a new Error will be thrown, directing the next action to be inside of the .catch(). Removed unnecessary handleQueueRender() call inside of getCurrentlyPlaying(). Also chained updatePlayedStatus() to GET in getCurrentlyPlaying(). 

Edited handleNextClick() to also updateTrackPlayedStatus() when clicked.