### PR TITLE
Open Spotify Alert on Home

### DIFF
--- a/client/src/utils/SpotifyAPI.js
+++ b/client/src/utils/SpotifyAPI.js
@@ -69,7 +69,7 @@ export default {
 	getPlaylistTracks: (token, playlistId) => {
 		return axios({
 			method: 'GET',
-			url: `https://api.spotify.com/v1/playlists/${playlistId}/tracks`,
+			url: `https://api.spotify.com/v1/playlists/${playlistId}/tracks?limit=100`,
 			headers: {
 				Authorization: 'Bearer ' + token
 			}


### PR DESCRIPTION
Created alert that will show on the Home screen if a user does not currently have Spotify open with a track playing. Once the user has completed those steps, they can click Continue and the alert will go away. Renamed showAlert state to playlistAlert to avoid confusion between the two alerts. 

I updated the setTimeout length for the setUrl calls inside of syncQueueWithRoomAndJoin and createPlaylistRoom. The timeout length with now correlate with how many tracks are inside of the array being added to their queue and/or Room in DB. 

I also edited SpotifyAPI.getPlaylistTracks call url to contain a limit of 100 tracks.